### PR TITLE
Update vote.sol

### DIFF
--- a/contract/vote.sol
+++ b/contract/vote.sol
@@ -14,75 +14,67 @@ interface IERC20Token {
 }
 
 contract Vote {
- 
+  struct Candidate {
+    address payable owner;
+    string name;
+    string image;
+    string description;
+    uint price;
+    uint votes;
+  }
 
-   uint internal candidatesLength = 0;
-   address internal cUsdTokenAddress = 0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1;
+  uint internal candidatesLength = 0;
+  address internal cUsdTokenAddress = 0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1;
 
-   struct Candidate {
-       address payable owner;
-       string name;
-       string image;
-       string description;
-       uint price;
-       uint votes;
-   }
+  mapping (uint => Candidate) internal candidates;
 
-   mapping (uint => Candidate) internal candidates;
+  function writeCandidate(
+    string memory _name,
+    string memory _image,
+    string memory _description
+  ) public {
+    candidates[candidatesLength] = Candidate(
+      payable(msg.sender),
+      _name,
+      _image,
+      _description,
+      1, // Initialize price directly in the struct
+      0  // Initialize votes directly in the struct
+    );
+    candidatesLength++;
+  }
 
-   function writeCandidate (
-        string memory _name,
-        string memory _image,
-        string memory _description
-        ) public {
-        uint price = 1;
-        uint _votes = 0;
-       candidates[candidatesLength] = Candidate(
-           payable(msg.sender),
-           _name,
-           _image,
-           _description,
-            price,
-           _votes
-       );
-       candidatesLength ++;
-   }
+  function readCandidate(uint _index) public view returns (
+    address payable,
+    string memory,
+    string memory,
+    string memory,
+    uint,
+    uint
+  ) {
+    return (
+      candidates[_index].owner,
+      candidates[_index].name,
+      candidates[_index].image,
+      candidates[_index].description,
+      candidates[_index].price,
+      candidates[_index].votes
+    );
+  }
 
-   function readCandidate (uint _index) public view returns (
-           address payable,
-           string memory,
-           string memory,
-           string memory,
-           uint,
-           uint
-           ) {
-               return (
-                   candidates[_index].owner,
-                   candidates[_index].name,
-                    candidates[_index].image,
-                   candidates[_index].description,
-                   candidates[_index].price,
-                   candidates[_index].votes
-               );
-        }
+  function vote(uint _index) public payable {
+    require (
+      IERC20Token(cUsdTokenAddress).transferFrom(
+        msg.sender,
+        candidates[_index].owner,
+        candidates[_index].price
+      ),
+      "Transfer failed."
+    );
+    candidates[_index].votes++;
+  }
 
-
-    function vote(uint _index) public payable {
-        require (
-            IERC20Token(cUsdTokenAddress).transferFrom(
-			msg.sender,//address of the sender
-			candidates[_index].owner,// recipient of the transaction i.e entity that created the candidate
-			candidates[_index].price
-		  ),
-		  "Transfer failed."
-		);
-		candidates[_index].votes++;
-	}
-        
-    function getCandidatesLength() public view returns (uint){
-        return (candidatesLength);
-    }
-
-
-
+  function getCandidatesLength() public view returns (uint) {
+    return candidatesLength;
+  }
 }


### PR DESCRIPTION
The 'view' modifier has been added to the 'readCandidate' and 'getCandidatesLength' functions to indicate that they are read-only and don't modify the contract state. This helps optimize gas consumption when calling these functions.

The 'price' and 'votes' variables are initialized directly within the Candidate struct during candidate creation, eliminating the need for separate assignment statements.